### PR TITLE
Adafruit board support

### DIFF
--- a/gg_interface/src/main.cpp
+++ b/gg_interface/src/main.cpp
@@ -26,6 +26,7 @@ void setup() {
         if (!ina260.begin()) {
             debug_msg(F("Couldn't find INA260!"));
             retries--;
+            continue;
         }
         debug_msg(F("Found INA260!"));
         break;

--- a/gg_interface/src/main.cpp
+++ b/gg_interface/src/main.cpp
@@ -4,6 +4,9 @@ Adafruit_INA260 ina260 = Adafruit_INA260();
 bool initialized = false;
 
 void setup() {
+    // In case there is no 10k resistor on the ALERT line
+    pinMode(ALERT_PIN, INPUT_PULLUP);
+
     // Every embedded system needs an LED
     pinMode(LED_PIN, OUTPUT);
     digitalWrite(LED_PIN, HIGH);


### PR DESCRIPTION
This PR adds support for the Adafruit INA260 breakout board, which lacks a 10k ohm pull-up resistor on its ALERT line.

Also fixes a bug with the INA260 "retry" where it was not actually retrying the connection.